### PR TITLE
rreplay.py: avoid spamming strace with ENOENT errors during cleanup()

### DIFF
--- a/rreplay.py
+++ b/rreplay.py
@@ -159,9 +159,10 @@ def wait_on_handles(subjects):
 
 
 def cleanup():
-    os.unlink('proc.out')
-    os.unlink('rrdump_proc.pipe')
-
+    file_list = ['proc.out', 'rrdump_proc.pipe']
+    for f in file_list:
+        if os.path.exists(f):
+            os.unlink(f)
 
 def main(ini_path):
     rr_dir, subjects = get_configuration(ini_path)


### PR DESCRIPTION
Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>