### PR TITLE
Added rrinit module

### DIFF
--- a/cpuid.c
+++ b/cpuid.c
@@ -1,0 +1,108 @@
+#include <stdint.h>
+#include <string.h>
+#include <python2.7/Python.h>
+
+
+/* docstrings for method */
+static char cpuid_docstring[] =
+        "Checks for appropriate vendor string and processor microarchitecture.";
+
+/* available functions for interface */
+static PyObject* cpuid_check(PyObject *self, PyObject *noargs);
+
+/* module specification */
+static PyMethodDef module_methods[] = {
+        {"cpuid_check", cpuid_check, METH_VARARGS, cpuid_docstring},
+        {NULL, NULL, 0, NULL}
+};
+
+/* initialize the module */
+PyMODINIT_FUNC initcpuid(void)
+{
+        (void) Py_InitModule("cpuid", module_methods);
+}
+
+/* represents CPUID microarchs (already unmasked) that are supported */
+static const uint32_t valid_pmu_cpu_type[25] = {
+        0x106A0, 0x106E0, 0x206E0,          // IntelNehalem
+        0x20650, 0x206C0, 0x206F0,          // IntelWestmere
+        0x206A0, 0x206D0, 0x306e0,          // IntelSandyBridge
+        0x306A0,                            // IntelIvyBridge
+        0x306C0, 0x306F0, 0x40650, 0x40660, // IntelHaswell
+        0x306D0, 0x40670, 0x406F0, 0x50660, // IntelBroadwell
+        0x406e0, 0x50650, 0x506e0,          // IntelSkylake
+        0x30670, 0x50670,                   // IntelSilvermont
+        0x806e0, 0x906e0                    // IntelKabylake
+};
+
+/* inline assembly interface to cpuid */
+static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)
+{
+        asm volatile("cpuid"
+            : "=a" (*eax),
+              "=b" (*ebx),
+              "=c" (*ecx),
+              "=d" (*edx)
+            : "0" (*eax), "2" (*ecx));
+}
+
+/* returns processor information in eax register */
+static uint32_t cpuid_processor_info()
+{
+        /* temporary registers to hold results */
+        uint32_t eax, ebx, ecx, edx;
+
+        /* eax = 1 for processor information */
+        eax = 1;
+
+        /* use all registers for output consuming purposes. */
+        cpuid(&eax, &ebx, &ecx, &edx);
+
+        /* return signature, must be unmasked */
+        return eax;
+}
+
+/* stores vendor string in provided char pointer */
+static void cpuid_vendor(char * name)
+{
+        /* set 12th char to 0 */
+        name[12] = 0;
+
+        /* eax = 0 for vendor */
+        uint32_t eax;
+        eax = 0;
+
+        /* call cpuid, storing output in ebx, edx, and ecx */
+        cpuid(&eax, (uint32_t *) &name[0], (uint32_t *) &name[8], (uint32_t *) &name[4]);
+}
+
+/* main Python interface */
+static PyObject* cpuid_check(PyObject *self, PyObject *noargs)
+{
+        int i;
+
+        /* check vendor: only Intel and AMD processors supported */
+        char vendor[13];
+        cpuid_vendor(vendor);
+
+        if (strcmp(vendor, "GenuineIntel")) {
+                PyErr_SetString(PyExc_RuntimeError, "invalid vendor string");
+                return NULL;
+        }
+
+        /* check CPU microarchitecture through unmask */
+        uint32_t cpuid_data = cpuid_processor_info();
+        uint32_t cpu_type = cpuid_data & 0xF0FF0;
+
+        /* check if microarchitecture is appropriate for use */
+        for (i=0; i <= sizeof(valid_pmu_cpu_type); i++){
+                if (valid_pmu_cpu_type[i] == cpu_type) {
+                        /* return a exit code 0 */
+                        return Py_BuildValue("i", 0);
+                }
+        }
+
+        /* returned if microarchitecture is not found */
+        PyErr_SetString(PyExc_RuntimeError, "unsupported CPU microarchitecture");
+        return NULL;
+}

--- a/parse_syscall_definitions.py
+++ b/parse_syscall_definitions.py
@@ -1,9 +1,13 @@
 """
+<Program Name>
+  parse_syscall_definitions
+
 <Started>
   June 2013
 
 <Author>
   Savvas Savvides <savvas@purdue.edu>
+  Alan Cao <ac7758@nyu.edu>
 
 <Purpose>
   Parse the definitions of all system calls from their man pages.
@@ -30,6 +34,7 @@
 import re
 import signal
 import subprocess
+import pickle
 
 from sysDef.SyscallManual import SyscallManual, SyscallManualException
 
@@ -114,57 +119,9 @@ def get_syscall_definitions_list(syscall_names_list):
 
 
 
-def print_definitions1(syscall_definitions_list):
-    """
-    A view of the parsed definitions. Prints the number of system call names
-    parsed, the list of all the system call names and a list of all the
-    definitions.
-    """
-
-    print "A total of", len(syscall_definitions_list), "system call names were parsed."
-    print
-    print
-
-    print"List of system call names:"
-    print"--------------------------"
-
-    for sd in syscall_definitions_list:
-        print sd.name
-
-    print
-    print
-
-    print "List of system call definitions:"
-    print "--------------------------------"
 
 
-    for sd in syscall_definitions_list:
-        print sd
-        print
-
-    print
-    print
-
-
-
-def print_definitions2(syscall_definitions_list):
-    """
-    A view of the parsed definitions. Prints only the list of parsed definitions.
-    Skips the system calls for which a definition was not found (for any reason).
-    """
-
-    print "List of all syscall definitions found"
-    print "====================================="
-    for sd in syscall_definitions_list:
-        if(sd.type == SyscallManual.FOUND):
-            print sd.definition
-
-    print
-    print
-
-
-
-def print_definitions3(syscall_definitions_list):
+def print_definitions(syscall_definitions_list):
     """
     A view of the parsed definitions.
     - Lists the syscall names for which a definition was NOT found.
@@ -241,13 +198,10 @@ def print_definitions3(syscall_definitions_list):
 
 
 
-def pickle_syscall_definitions(syscall_definitions_list):
-    """
-    Store the syscall_definitions_list into a pickle file.
-    """
 
-    import pickle
-    pickle_name = "syscall_definitions.pickle"
+
+def pickle_syscall_definitions(syscall_definitions_list, target_dir):
+    pickle_name = target_dir + "syscall_definitions.pickle"
     pickle_file = open(pickle_name, 'wb')
     pickle.dump(syscall_definitions_list, pickle_file)
     pickle_file.close()
@@ -255,22 +209,20 @@ def pickle_syscall_definitions(syscall_definitions_list):
 
 
 
-def main():
 
+def generate_pickle(target_dir='./'):
+    
     # get a list with all the system call names available in this system.
     syscall_names_list = parse_syscall_names_list()
+    
+    # output definitions
+    #print_definitions(syscall_names_list)
 
     # use the list of names just parsed to generate a list of system call
     # definitions.
     syscall_definitions_list = get_syscall_definitions_list(syscall_names_list)
 
-    # different views:
-    print_definitions1(syscall_definitions_list)
-    print_definitions2(syscall_definitions_list)
-    print_definitions3(syscall_definitions_list)
-
+    # Alan - for CrashSimulator purposes, we will keep this quiet
     # pickle syscall_definitions_list
-    pickle_syscall_definitions(syscall_definitions_list)
+    pickle_syscall_definitions(syscall_definitions_list, target_dir)
 
-if __name__ == "__main__":
-    main()

--- a/rrinit.py
+++ b/rrinit.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python2.7
+"""
+<Program Name>
+  rrinit
+
+<Started>
+  July 2018
+
+<Author>
+  Alan Cao
+
+<Purpose>
+  Executes initialization routines for the creation of a CrashSimulator
+  environment.
+
+  Before the user can create any tests and perform a record-replay
+  execution, the testing environment must be optimal for such use. This
+  application-level script checks for an optimal microarchitecture,
+  update necessary proc entries, creates a path for storing tests and
+  configs, and also generates the necessary syscall_definitions.pickle
+  file.
+
+  By running `rrinit`, a lot of the work can be taken out of `rrtest`
+  and `rreplay`, and users are able to catch environmental anomalies
+  before execution.
+
+"""
+
+import os
+import sys
+import subprocess
+import argparse
+import logging
+
+import cpuid
+import consts
+import parse_syscall_definitions
+
+def main():
+    
+    # initialize parser
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-g', '--generate', 
+                        dest='generate', 
+                        action='store_true',
+                        help='(re)generate syscall_definitions.pickle file')
+    parser.add_argument('-v', '--verbosity',
+                        dest='loglevel',
+                        action='store_const',
+                        const=logging.DEBUG,
+                        help='flag for displaying debug information')
+     
+    # parse arguments
+    args = parser.parse_args()    
+
+    # add simple logging for verbosity
+    logging.basicConfig(level=args.loglevel)
+
+    # check CPUID environment
+    logging.debug("Checking CPU architecture compatibility")
+    if cpuid.cpuid_check() != 0:
+        exit(1)
+
+    # checking if disabled ASLR
+    logging.debug("Checking if ASLR is disabled")
+    with open('/proc/sys/kernel/randomize_va_space', 'r') as p:
+        if p.read() == '1':
+            print "ASLR should be disabled. \
+            Set /proc/sys/kernel/randomize_va_space = 0"
+            sys.exit(1)
+
+    # checking if disabled ptrace on processes
+    logging.debug("Checking if ptrace on processes is enabled")
+    with open('/proc/sys/kernel/yama/ptrace_scope', 'r') as p:
+        if p.read() == '1':
+            print "ptrace on processes should be disabled \
+            Set /proc/sys/kernel/yama/ptrace_scope = 0"
+            sys.exit(1)
+
+    # check to see if rr is a valid shell-level command.
+    # error status is nonzero
+    logging.debug("Checking if `rr` is a valid shell command")
+    try:
+        with open(os.devnull, 'w') as fnull:
+            subprocess.check_call(['rr', 'help'],
+                                 stdout=fnull,
+                                 stderr=subprocess.STDOUT)
+    # in the case that the command failed to execute for internal reasons
+    except subprocess.CalledProcessError:
+        print 'rr was found by "rr help" exited with an error.'
+        sys.exit(1)
+    # in the case that the command is not valid at all
+    except OSError:
+        print 'rr command is not found. Make sure it is installed and described within your $PATH'
+        sys.exit(1)
+
+    # create ~/.crashsim/
+    if not os.path.exists(consts.DEFAULT_CONFIG_PATH):
+        logging.debug("Creating configuration path")
+        try:
+            os.makedirs(consts.DEFAULT_CONFIG_PATH)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+    # check for existence of rrdump pipe
+    logging.debug("Checking if pipe already exists")
+    if os.path.exists(consts.DEFAULT_CONFIG_PATH + "rrdump.pipe"):
+        os.unlink(consts.DEFAULT_CONFIG_PATH + "rrdump.pipe")
+
+    # generate pickle
+    if not os.path.exists(consts.DEFAULT_CONFIG_PATH + "syscall_definitions.pickle"):
+        print "syscall_definitions.pickle does NOT exist. Regenerating."
+        parse_syscall_definitions.generate_pickle()         
+    
+    print "\n=========================================================="
+    print "Sucessfully initialized CrashSimulator environment!"
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/rrinit.py
+++ b/rrinit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2.7
+# pylint: disable=missing-docstring, bad-indentation
 """
 <Program Name>
   rrinit
@@ -28,6 +29,7 @@
 
 import os
 import sys
+import errno
 import subprocess
 import argparse
 import logging
@@ -37,86 +39,84 @@ import consts
 import parse_syscall_definitions
 
 def main():
-    
-    # initialize parser
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-g', '--generate', 
-                        dest='generate', 
-                        action='store_true',
-                        help='(re)generate syscall_definitions.pickle file')
-    parser.add_argument('-v', '--verbosity',
-                        dest='loglevel',
-                        action='store_const',
-                        const=logging.DEBUG,
-                        help='flag for displaying debug information')
-     
-    # parse arguments
-    args = parser.parse_args()    
+  # initialize parser
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-g', '--generate',
+                      dest='generate',
+                      action='store_true',
+                      help='(re)generate syscall_definitions.pickle file')
+  parser.add_argument('-v', '--verbosity',
+                      dest='loglevel',
+                      action='store_const',
+                      const=logging.DEBUG,
+                      help='flag for displaying debug information')
 
-    # add simple logging for verbosity
-    logging.basicConfig(level=args.loglevel)
+  # parse arguments
+  args = parser.parse_args()
 
-    # check CPUID environment
-    logging.debug("Checking CPU architecture compatibility")
-    if cpuid.cpuid_check() != 0:
-        exit(1)
+  # add simple logging for verbosity
+  logging.basicConfig(level=args.loglevel)
 
-    # checking if disabled ASLR
-    logging.debug("Checking if ASLR is disabled")
-    with open('/proc/sys/kernel/randomize_va_space', 'r') as p:
-        if p.read() == '1':
-            print "ASLR should be disabled. \
-            Set /proc/sys/kernel/randomize_va_space = 0"
-            sys.exit(1)
+  # check CPUID environment
+  logging.debug("Checking CPU architecture compatibility")
+  if cpuid.cpuid_check() != 0:
+    exit(1)
 
-    # checking if disabled ptrace on processes
-    logging.debug("Checking if ptrace on processes is enabled")
-    with open('/proc/sys/kernel/yama/ptrace_scope', 'r') as p:
-        if p.read() == '1':
-            print "ptrace on processes should be disabled \
-            Set /proc/sys/kernel/yama/ptrace_scope = 0"
-            sys.exit(1)
+  # checking if disabled ASLR
+  logging.debug("Checking if ASLR is disabled")
+  with open('/proc/sys/kernel/randomize_va_space', 'r') as proc:
+    if proc.read() == '1':
+      print "ASLR should be disabled. \
+      Set /proc/sys/kernel/randomize_va_space = 0"
+      sys.exit(1)
 
-    # check to see if rr is a valid shell-level command.
-    # error status is nonzero
-    logging.debug("Checking if `rr` is a valid shell command")
+  # checking if disabled ptrace on processes
+  logging.debug("Checking if ptrace on processes is enabled")
+  with open('/proc/sys/kernel/yama/ptrace_scope', 'r') as proc:
+    if proc.read() == '1':
+      print "ptrace on processes should be disabled \
+      Set /proc/sys/kernel/yama/ptrace_scope = 0"
+      sys.exit(1)
+
+  # check to see if rr is a valid shell-level command.
+  # error status is nonzero
+  logging.debug("Checking if `rr` is a valid shell command")
+  try:
+    with open(os.devnull, 'w') as fnull:
+      subprocess.check_call(['rr', 'help'],
+                           stdout=fnull,
+													 stderr=subprocess.STDOUT)
+  # in the case that the command failed to execute for internal reasons
+  except subprocess.CalledProcessError:
+    print 'rr was found by "rr help" exited with an error.'
+    sys.exit(1)
+  # in the case that the command is not valid at all
+  except OSError:
+    print 'rr command is not found. Make sure it is installed and described within your $PATH'
+    sys.exit(1)
+
+  # create ~/.crashsim/
+  if not os.path.exists(consts.DEFAULT_CONFIG_PATH):
+    logging.debug("Creating configuration path")
     try:
-        with open(os.devnull, 'w') as fnull:
-            subprocess.check_call(['rr', 'help'],
-                                 stdout=fnull,
-                                 stderr=subprocess.STDOUT)
-    # in the case that the command failed to execute for internal reasons
-    except subprocess.CalledProcessError:
-        print 'rr was found by "rr help" exited with an error.'
-        sys.exit(1)
-    # in the case that the command is not valid at all
-    except OSError:
-        print 'rr command is not found. Make sure it is installed and described within your $PATH'
-        sys.exit(1)
+      os.makedirs(consts.DEFAULT_CONFIG_PATH)
+    except OSError as err:
+      if err.errno != errno.EEXIST:
+        raise
 
-    # create ~/.crashsim/
-    if not os.path.exists(consts.DEFAULT_CONFIG_PATH):
-        logging.debug("Creating configuration path")
-        try:
-            os.makedirs(consts.DEFAULT_CONFIG_PATH)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+  # check for existence of rrdump pipe
+  logging.debug("Checking if pipe already exists")
+  if os.path.exists(consts.DEFAULT_CONFIG_PATH + "rrdump.pipe"):
+    os.unlink(consts.DEFAULT_CONFIG_PATH + "rrdump.pipe")
 
-    # check for existence of rrdump pipe
-    logging.debug("Checking if pipe already exists")
-    if os.path.exists(consts.DEFAULT_CONFIG_PATH + "rrdump.pipe"):
-        os.unlink(consts.DEFAULT_CONFIG_PATH + "rrdump.pipe")
-
-    # generate pickle
-    if not os.path.exists(consts.DEFAULT_CONFIG_PATH + "syscall_definitions.pickle"):
-        print "syscall_definitions.pickle does NOT exist. Regenerating."
-        parse_syscall_definitions.generate_pickle()         
-    
-    print "\n=========================================================="
-    print "Sucessfully initialized CrashSimulator environment!"
-    sys.exit(0)
+  # generate pickle
+  if not os.path.exists(consts.DEFAULT_CONFIG_PATH + "syscall_definitions.pickle"):
+    print "syscall_definitions.pickle does NOT exist. Regenerating."
+    parse_syscall_definitions.generate_pickle()
+  print "\n=========================================================="
+  print "Sucessfully initialized CrashSimulator environment!"
+  sys.exit(0)
 
 
 if __name__ == '__main__':
-    main()
+  main()


### PR DESCRIPTION
This PR is an improvement upon the last one that clears the unnecessary commits and merges.

This adds:
* `rrinit` - run to initialize the environment for `rreplay`. This performs all the preemptive checking necessary, and is great for isolated and sandbox environments.
* `cpuid.c` - low-level C code that complement `rrinit`. This provides `rrinit` the necessary methods for CPUID-related operations.

This modifies:
`parse_syscall_definitions` - changes this such that it can be imported as a library rather than another application. This reduces overhead created by spinning off the script through `subprocess`.