### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu
+
+########################
+# Initialization
+########################
+
+# get necessary dependencies and cleanup
+RUN apt-get -q update
+RUN apt-get -q -y install \
+      ccache cmake make g++-multilib gdb libdw-dev \
+      pkg-config coreutils python-pexpect manpages-dev git \
+      ninja-build capnproto libcapnp-dev autoconf \
+      libpython2.7-dev zlib1g-dev python-pip
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# get necessary CrashSimulator repos
+RUN git clone -b spin-off https://github.com/pkmoore/rr
+RUN git clone https://github.com/pkmoore/rrapper
+
+# create a new nonroot user
+RUN useradd crashsim -m
+
+########################
+# Installing modified rr
+########################
+
+WORKDIR rr/
+
+# compile and install the modified strace
+RUN cd third-party/strace && ./bootstrap && autoreconf && \
+    ./configure && make && make install
+
+# compile and install rr
+RUN mkdir obj && cd obj && cmake .. && make -j8 && \
+    make install
+
+########################
+# Installing rrapper 
+########################
+
+WORKDIR rrapper/
+
+# install rrdump
+RUN pip install ./rrdump
+
+# install requirements.txt
+RUN pip install -r requirements.txt
+
+# run setup.py
+RUN python setup.py install
+
+########################
+# Finalize
+########################
+
+USER crashsim
+RUN rrinit

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ $ echo kernel.yama.ptrace_scope = 0 | sudo tee /etc/sysctl.d/10-ptrace.conf
 
 ## 3.0 Installation
 
+### Automated Installation _(with Docker)_
+
+We use Docker in order to deploy the entire CrashSimulator codebase into an isolated container.
+
+```
+$ docker build -t crashsimulator .
+$ docker run -it crashsimulator
+```
+
+This starts an interactive session within the Ubuntu image in the container with all the necessar components installed.
+
+### Manual Installation
+
 After cloning this repository a few dependencies must be put in place:
 
 First, initialize a `virtualenv`:


### PR DESCRIPTION
This patch introduces a Dockerfile to the CrashSimulator codebase, which builds the modified `rr` fork, rrapper and all the other relevant modules.

To run:
```
$ docker build -t crashsimulator .
$ docker run -it crashsimulator
```

Keep in mind that this is from a minimal amount of Docker knowledge, so please give feedback if necessary!