### PR TITLE
README: add additional `docker run` flags required by rr

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ $ echo kernel.yama.ptrace_scope = 0 | sudo tee /etc/sysctl.d/10-ptrace.conf
 
 ### Automated Installation _(with Docker)_
 
-We use Docker in order to deploy the entire CrashSimulator codebase into an isolated container.
+We use Docker in order to deploy the entire CrashSimulator codebase into an isolated container. The
+`--cap-add=SYS_PTRACE` and `--security-opt seccomp=unconfined` flags are required to allow the usage of
+the `ptrace`, `perf_event_open`, and `process_vm_writev` system calls by rr within the container.
 
 ```
 $ docker build -t crashsimulator .
-$ docker run -it crashsimulator
+$ docker run --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it crashsimulator
 ```
 
 This starts an interactive session within the Ubuntu image in the container with all the necessary components installed.


### PR DESCRIPTION
For rr to use `ptrace`, `perf_event_open`, and `process_vm_writev` the
`--cap-add=SYS_PTRACE --security-opt seccomp=unconfined` flags must be
passed to `docker run`.

From [1]:

> By default docker drops the SYS_PTRACE capability which prevents ptrace
> from being used inside the container. That capability must be restored.
>
> Docker also includes by default a seccomp profile that disables a number
> of syscalls needed by rr, including ptrace, perf_event_open, and
> process_vm_writev.  It would be possible to audit rr and produce a seccomp
> profile for Docker that is the default profile with only the syscalls rr
> requires added back in, but we have not done that work.
> --security-opt seccomp=unconfined will skip all seccomp filtering of the
> container's processes.

Add these flags to the documentation.

[1] https://github.com/mozilla/rr/wiki/Docker

Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>