### PR TITLE
More dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM i386/ubuntu
-ENV MAKEFLAGS="-j8"
+
+ENV DEBIAN_FRONTEND noninteractive
+ARG RR_BRANCH=spin-off
+ARG RRAPPER_BRANCH=master
 
 ########################
 # Initialization
@@ -13,28 +16,25 @@ RUN apt-get update && apt-get -y install \
       libpython2.7-dev zlib1g-dev python-pip \
       gawk man libbz2-dev libunwind-dev
 
-# get necessary CrashSimulator repos
-RUN git clone -b spin-off https://github.com/pkmoore/rr
-RUN git clone https://github.com/pkmoore/rrapper rr/rrapper
-
-# create a new nonroot user
-RUN useradd crashsim -m
-
 ########################
 # Installing modified rr
 ########################
 
+RUN git clone -b ${RR_BRANCH} https://github.com/pkmoore/rr
+
 WORKDIR rr/
 
 # compile and install the modified strace
-RUN setarch i686 bash -c "cd third-party/strace && ./bootstrap && make && make install"
+RUN MAKEFLAGS="-j$(nproc)" setarch i686 bash -c "cd third-party/strace && ./bootstrap && make && make install"
 
 # compile and install rr
-RUN setarch i686 bash -c "mkdir obj && cd obj && cmake .. && make install"
+RUN MAKEFLAGS="-j$(nproc)" setarch i686 bash -c "mkdir obj && cd obj && cmake .. && make install"
 
 ########################
 # Installing rrapper
 ########################
+
+RUN git clone -b ${RRAPPER_BRANCH} https://github.com/pkmoore/rrapper
 
 WORKDIR rrapper/
 
@@ -55,5 +55,8 @@ RUN python setup.py install
 RUN rm /etc/dpkg/dpkg.cfg.d/excludes
 RUN apt-get install --reinstall -y manpages manpages-dev
 
+# create a new nonroot user
+RUN useradd crashsim -m
 USER crashsim
-RUN env rrinit
+WORKDIR /home/crashsim
+RUN rrinit


### PR DESCRIPTION
This PR makes the docker image a bit easier to use. It:
* Adds build-args to set which branch of rr and rrapper to build
* Sets `-j` based on the number of CPUs (instead of always 8)
* Places the user in the `crashsim` user homedir so they don't run into permission issues in the /rr folder (since that folder is writable by root only)