### PR TITLE
print_help() for command line parser

### DIFF
--- a/src/rrtest.py
+++ b/src/rrtest.py
@@ -357,6 +357,9 @@ def main():
       checker.transition(i)
     print(checker.is_accepting())
 
+  else:
+    parser.print_help()
+    sys.exit(1)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Small modification adds `print_help()` for more verbose help menu when users don't specify any positional or flag arguments.