### PR TITLE
Fix116 Syscall Trace Generator (ongoing)

### DIFF
--- a/src/inject.py
+++ b/src/inject.py
@@ -536,9 +536,7 @@ def main():
     checker = eval(syscallreplay.injected_state['config']['checker'])
   if 'mutator' in syscallreplay.injected_state['config']:
     mutator = eval(syscallreplay.injected_state['config']['mutator'])
-    mutator.mutate_trace(config_dict['trace_file'])
-    trace = Trace.Trace(config_dict['trace_file'], pickle_file)
-    syscallreplay.syscalls = trace.syscalls
+    mutator.mutate_syscalls(syscallreplay.syscalls)
 # pylint: enable=eval-used
 
   # Requires kernel.yama.ptrace_scope = 0

--- a/src/mutator/CrossdiskRename.py
+++ b/src/mutator/CrossdiskRename.py
@@ -24,9 +24,8 @@ class CrossdiskRenameMutator:
       for l in string_lines:
         f.write(l)
 
-  def identify_lines(self,trace):
+  def identify_lines(self, syscalls):
     lines = []
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
     for k, v in enumerate(syscalls):
       if v.name == 'rename':
         if self.name:

--- a/src/mutator/CrossdiskRename.py
+++ b/src/mutator/CrossdiskRename.py
@@ -1,28 +1,19 @@
-from posix_omni_parser import Trace
-import sys
-from ..consts import DEFAULT_CONFIG_PATH
-
-class CrossdiskRenameMutator:
+from mutator import GenericMutator
 
 
+class CrossdiskRenameMutator(GenericMutator):
   def __init__(self, name=None):
       self.name = name
 
 
-  def mutate_trace(self, trace):
-    with open(trace, 'r') as f:
-      string_lines = f.readlines()
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+  def mutate_syscalls(self, syscalls):
     for k, v in enumerate(syscalls):
       if v.name == 'rename':
         if self.name:
           if v.args[0].value != self.name:
             continue
-        string_lines[k] = string_lines[k].replace(' = 0', ' = -1 EXDEV (Invalid cross-device link')
-        print(string_lines[k])
-    with open(trace, 'w') as f:
-      for l in string_lines:
-        f.write(l)
+          syscalls[k].ret = (-1, 'EXDEV')
+
 
   def identify_lines(self, syscalls):
     lines = []

--- a/src/mutator/FsyncNoSpace.py
+++ b/src/mutator/FsyncNoSpace.py
@@ -24,9 +24,8 @@ class FsyncNoSpaceMutator:
       for l in string_lines:
         f.write(l)
 
-  def identify_lines(self,trace):
+  def identify_lines(self, syscalls):
     lines = []
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
     for k, v in enumerate(syscalls):
       if v.name == 'fsync':
         if self.name:

--- a/src/mutator/FsyncNoSpace.py
+++ b/src/mutator/FsyncNoSpace.py
@@ -1,28 +1,23 @@
 from posix_omni_parser import Trace
 import sys
+from mutator import GenericMutator
 from ..consts import DEFAULT_CONFIG_PATH
 
-class FsyncNoSpaceMutator:
+class FsyncNoSpaceMutator(GenericMutator):
 
 
   def __init__(self, name=None):
       self.name = name
 
 
-  def mutate_trace(self, trace):
-    with open(trace, 'r') as f:
-      string_lines = f.readlines()
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+  def mutate_syscalls(self, syscalls):
     for k, v in enumerate(syscalls):
       if v.name == 'fsync':
         if self.name:
           if v.args[0].value != self.name:
             continue
-        string_lines[k] = string_lines[k].replace(' = 0', ' = -1 ENOSPACE (No space left on device)')
-        print(string_lines[k])
-    with open(trace, 'w') as f:
-      for l in string_lines:
-        f.write(l)
+        syscalls[k].ret = (-1, 'ENOSPACE')
+
 
   def identify_lines(self, syscalls):
     lines = []

--- a/src/mutator/FutureTime.py
+++ b/src/mutator/FutureTime.py
@@ -20,9 +20,8 @@ class FutureTimeMutator:
       for l in string_lines:
         f.write(l)
 
-  def identify_lines(self,trace):
+  def identify_lines(self, syscalls):
     lines = []
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
     for k, v in enumerate(syscalls):
       if v.name == 'time':
         lines.append(k)

--- a/src/mutator/FutureTime.py
+++ b/src/mutator/FutureTime.py
@@ -1,28 +1,12 @@
-from posix_omni_parser import Trace
-import sys
-from ..consts import DEFAULT_CONFIG_PATH
-
-class FutureTimeMutator:
+from mutator import GenericMutator
 
 
+class FutureTimeMutator(GenericMutator):
   def __init__(self, seconds=100):
       self.seconds = seconds
 
 
-  def mutate_trace(self, trace):
-    with open(trace, 'r') as f:
-      string_lines = f.readlines()
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+  def mutate_syscalls(self, syscalls):
     for k, v in enumerate(syscalls):
       if v.name == 'time':
-        string_lines[k] = string_lines[k].replace(str(v.ret[0]), str(int(v.ret[0])+self.seconds))
-    with open(trace, 'w') as f:
-      for l in string_lines:
-        f.write(l)
-
-  def identify_lines(self, syscalls):
-    lines = []
-    for k, v in enumerate(syscalls):
-      if v.name == 'time':
-        lines.append(k)
-    return lines
+        syscalls[k].ret = (syscalls[k].ret[0] + self.seconds, '')

--- a/src/mutator/MutationError.py
+++ b/src/mutator/MutationError.py
@@ -1,0 +1,2 @@
+class MutationError(RuntimeError):
+  pass

--- a/src/mutator/Null.py
+++ b/src/mutator/Null.py
@@ -4,8 +4,8 @@ class NullMutator(GenericMutator):
   def __init__(self, index=0):
     self.index = index
 
-  def mutate_trace(self, trace):
-    return trace
+  def mutate_syscalls(self, syscalls):
+    pass
 
-  def identify_lines(self, trace):
+  def identify_lines(self, syscalls):
     return [self.index]

--- a/src/mutator/ReverseTime.py
+++ b/src/mutator/ReverseTime.py
@@ -1,24 +1,15 @@
-from posix_omni_parser import Trace
-import sys
-from ..consts import DEFAULT_CONFIG_PATH
-
-class ReverseTimeMutator:
+from mutator import GenericMutator
 
 
+class ReverseTimeMutator(GenericMutator):
   def __init__(self, seconds=100):
       self.seconds = seconds
 
 
-  def mutate_trace(self, trace):
-    with open(trace, 'r') as f:
-      string_lines = f.readlines()
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+  def mutate_syscalls(self, syscalls):
     for k, v in enumerate(syscalls):
       if v.name == 'time':
-        string_lines[k] = string_lines[k].replace(str(v.ret[0]), str(int(v.ret[0])-self.seconds))
-    with open(trace, 'w') as f:
-      for l in string_lines:
-        f.write(l)
+        syscalls[k].ret = (syscalls[k].ret[0] - self.seconds, '')
 
   def identify_lines(self, syscalls):
     lines = []

--- a/src/mutator/ReverseTime.py
+++ b/src/mutator/ReverseTime.py
@@ -20,9 +20,8 @@ class ReverseTimeMutator:
       for l in string_lines:
         f.write(l)
 
-  def identify_lines(self,trace):
+  def identify_lines(self, syscalls):
     lines = []
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
     for k, v in enumerate(syscalls):
       if v.name == 'time':
         lines.append(k)

--- a/src/mutator/UnusualFiletype.py
+++ b/src/mutator/UnusualFiletype.py
@@ -1,18 +1,13 @@
-from posix_omni_parser import Trace
-import sys
-from ..consts import DEFAULT_CONFIG_PATH
+from mutator import GenericMutator
 from MutationError import MutationError
 
-class UnusualFiletypeMutator:
 
-
+class UnusualFiletypeMutator(GenericMutator):
   def __init__(self, filetype='S_IFREG', name=None, file_descriptor=None):
-    if name != None and file_desciptor != None:
-      print('Both name and file_descriptor cannot be set at the same time')
-      sys.exit(1)
+    if name is not None and file_descriptor is not None:
+      raise MutationError('Cannot specify both a name and a file_descriptor')
     self.filetype = filetype
     self.name = name
-    self.name = None
     self.file_descriptor = file_descriptor
 
 
@@ -58,5 +53,3 @@ class UnusualFiletypeMutator:
             continue
         lines.append(k)
     return lines
-
-

--- a/src/mutator/UnusualFiletype.py
+++ b/src/mutator/UnusualFiletype.py
@@ -45,9 +45,8 @@ class UnusualFiletypeMutator:
             continue
         return k
 
-  def identify_lines(self,trace):
+  def identify_lines(self, syscalls):
     lines = []
-    syscalls = Trace.Trace(trace, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
     for k, v in enumerate(syscalls):
       # fstat takes a file descriptor
       if v.name.startswith('fstat'):

--- a/src/mutator/test_CrossdiskRename.py
+++ b/src/mutator/test_CrossdiskRename.py
@@ -1,0 +1,87 @@
+''' Tests for the CrossdiskRenameMutator
+'''
+
+import unittest
+import mock
+from bunch import Bunch
+import tempfile
+from posix_omni_parser import Trace
+
+from ..consts import DEFAULT_CONFIG_PATH
+
+from CrossdiskRename import CrossdiskRenameMutator
+
+class TestIdentify(unittest.TestCase):
+  '''Test identify_opportunities
+  '''
+
+  def test_identify_with_no_opportunities(self):
+    '''CrossdiskRenameMutator should find no opportunities in a trace
+    with no stat-like calls
+    '''
+
+    trace_data = '''2503  mmap2(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0xb7e05000
+2503  set_thread_area({entry_number:-1, base_addr:0xb7e05700, limit:1048575, seg_32bit:1, contents:0, read_exec_only:0, limit_in_pages:1, seg_not_present:0, useable:1}) = 0 (entry_number:6)
+2503  mprotect(0xb7fb6000, 8192, PROT_READ) = 0
+2503  mprotect(0x8049000, 4096, PROT_READ) = 0
+2503  mprotect(0xb7ffe000, 4096, PROT_READ) = 0
+2503  munmap(0xb7fbc000, 100584)        = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = CrossdiskRenameMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 0)
+
+
+  def test_identify_with_one_opportunities(self):
+    '''CrossdiskRenameMutator should find one opportunity in a trace with
+    one stat-like call
+
+    '''
+    trace_data = '''2503  mmap2(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0xb7e05000
+2503  set_thread_area({entry_number:-1, base_addr:0xb7e05700, limit:1048575, seg_32bit:1, contents:0, read_exec_only:0, limit_in_pages:1, seg_not_present:0, useable:1}) = 0 (entry_number:6)
+2503  mprotect(0xb7fb6000, 8192, PROT_READ) = 0
+2503  rename("test/test.txt", "test/test2.txt") = 0
+2503  mprotect(0x8049000, 4096, PROT_READ) = 0
+2503  mprotect(0xb7ffe000, 4096, PROT_READ) = 0
+2503  munmap(0xb7fbc000, 100584)        = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = CrossdiskRenameMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 1)
+
+
+  def test_identify_with_many_opportunities(self):
+    '''CrossdiskRenameMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+
+    trace_data = '''2503  mmap2(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0xb7e05000
+2503  set_thread_area({entry_number:-1, base_addr:0xb7e05700, limit:1048575, seg_32bit:1, contents:0, read_exec_only:0, limit_in_pages:1, seg_not_present:0, useable:1}) = 0 (entry_number:6)
+2503  mprotect(0xb7fb6000, 8192, PROT_READ) = 0
+2503  rename("test/test.txt", "test/test2.txt") = 0
+2503  mprotect(0x8049000, 4096, PROT_READ) = 0
+2503  mprotect(0xb7ffe000, 4096, PROT_READ) = 0
+2503  munmap(0xb7fbc000, 100584)        = 0
+2503  rename("test/test.txt", "test/test2.txt") = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = CrossdiskRenameMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 2)

--- a/src/mutator/test_FsyncNoSpace.py
+++ b/src/mutator/test_FsyncNoSpace.py
@@ -1,0 +1,83 @@
+''' Tests for the FsyncNoSpaceMutator
+'''
+
+import unittest
+import mock
+from bunch import Bunch
+import tempfile
+from posix_omni_parser import Trace
+
+from ..consts import DEFAULT_CONFIG_PATH
+
+from FsyncNoSpace import FsyncNoSpaceMutator
+
+class TestIdentify(unittest.TestCase):
+  '''Test identify_opportunities
+  '''
+
+  def test_identify_with_no_opportunities(self):
+    '''FsyncNoSpaceMutator should find no opportunities in a trace
+    with no stat-like calls
+    '''
+
+    trace_data = r''' 5414  munmap(0xb7fbc000, 100584)        = 0
+5414  fstat64(1, {st_dev=makedev(0, 21), st_ino=13, st_mode=S_IFCHR|0620, st_nlink=1, st_uid=1000, st_gid=5, st_blksize=1024, st_blocks=0, st_rdev=makedev(136, 10), st_atime=2019/06/06-10:29:52.005720855, st_mtime=2019/06/06-10:29:52.005720855, st_ctime=2019/06/05-19:12:41.005720855}) = 0
+5414  brk(NULL)                         = 0x804b000
+5414  brk(0x806c000)                    = 0x806c000
+5414  write(1, "Fsync please!\n", 14)   = 14
+'''
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = FsyncNoSpaceMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 0)
+
+
+  def test_identify_with_one_opportunities(self):
+    '''FsyncNoSpaceMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+
+    trace_data = r''' 5414  munmap(0xb7fbc000, 100584)        = 0
+5414  fstat64(1, {st_dev=makedev(0, 21), st_ino=13, st_mode=S_IFCHR|0620, st_nlink=1, st_uid=1000, st_gid=5, st_blksize=1024, st_blocks=0, st_rdev=makedev(136, 10), st_atime=2019/06/06-10:29:52.005720855, st_mtime=2019/06/06-10:29:52.005720855, st_ctime=2019/06/05-19:12:41.005720855}) = 0
+5414  brk(NULL)                         = 0x804b000
+5414  brk(0x806c000)                    = 0x806c000
+5414  write(1, "Fsync please!\n", 14)   = 14
+5414  fsync(0)                          = 0
+'''
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = FsyncNoSpaceMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 1)
+
+
+  def test_identify_with_many_opportunities(self):
+    '''FsyncNoSpaceMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+
+    trace_data = r'''5414  munmap(0xb7fbc000, 100584)        = 0
+5414  fstat64(1, {st_dev=makedev(0, 21), st_ino=13, st_mode=S_IFCHR|0620, st_nlink=1, st_uid=1000, st_gid=5, st_blksize=1024, st_blocks=0, st_rdev=makedev(136, 10), st_atime=2019/06/06-10:29:52.005720855, st_mtime=2019/06/06-10:29:52.005720855, st_ctime=2019/06/05-19:12:41.005720855}) = 0
+5414  brk(NULL)                         = 0x804b000
+5414  brk(0x806c000)                    = 0x806c000
+5414  write(1, "Fsync please!\n", 14)   = 14
+5414  fsync(0)                          = 0
+5414  fsync(0)                          = 0
+5414  fsync(0)                          = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = FsyncNoSpaceMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 3)

--- a/src/mutator/test_FutureTime.py
+++ b/src/mutator/test_FutureTime.py
@@ -1,0 +1,77 @@
+
+''' Tests for the FutureTimeMutator
+'''
+
+import unittest
+import mock
+from bunch import Bunch
+import tempfile
+from posix_omni_parser import Trace
+
+from ..consts import DEFAULT_CONFIG_PATH
+
+from FutureTime import FutureTimeMutator
+
+class TestIdentify(unittest.TestCase):
+  '''Test identify_opportunities
+  '''
+
+  def test_identify_with_no_opportunities(self):
+    '''FutureTimeMutator should find no opportunities in a trace
+    with no time calls
+    '''
+    trace_data = r'''32473 stat64("/etc/localtime", {st_dev=makedev(8, 1), st_ino=934975, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2845, st_atime=1559715707 /* 2019-06-04T23:21:47.447272045-0700 */, st_atime_nsec=447272045, st_mtime=1555516381 /* 2019-04-17T08:53:01-0700 */, st_mtime_nsec=0, st_ctime=1556825835 /* 2019-05-02T12:37:15.298850882-0700 */, st_ctime_nsec=298850882}) = 0
+32473 write(1, "Current local time and date: Wed Jun  5 19:15:04 2019\n", 54) = 54
+32473 nanosleep({tv_sec=5, tv_nsec=0}, 0xbffff298) = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = FutureTimeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 0)
+
+
+  def test_identify_with_one_opportunities(self):
+    '''FutureTimeMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+    trace_data = r'''32473 time([1559787304 /* 2019-06-05T19:15:04-0700 */]) = 1559787304 (2019-06-05T19:15:04-0700)
+32473 stat64("/etc/localtime", {st_dev=makedev(8, 1), st_ino=934975, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2845, st_atime=1559715707 /* 2019-06-04T23:21:47.447272045-0700 */, st_atime_nsec=447272045, st_mtime=1555516381 /* 2019-04-17T08:53:01-0700 */, st_mtime_nsec=0, st_ctime=1556825835 /* 2019-05-02T12:37:15.298850882-0700 */, st_ctime_nsec=298850882}) = 0
+32473 write(1, "Current local time and date: Wed Jun  5 19:15:04 2019\n", 54) = 54
+32473 nanosleep({tv_sec=5, tv_nsec=0}, 0xbffff298) = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = FutureTimeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 1)
+
+
+  def test_identify_with_many_opportunities(self):
+    '''FutureTimeMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+
+    trace_data = r'''32473 time([1559787304 /* 2019-06-05T19:15:04-0700 */]) = 1559787304 (2019-06-05T19:15:04-0700)
+32473 stat64("/etc/localtime", {st_dev=makedev(8, 1), st_ino=934975, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2845, st_atime=1559715707 /* 2019-06-04T23:21:47.447272045-0700 */, st_atime_nsec=447272045, st_mtime=1555516381 /* 2019-04-17T08:53:01-0700 */, st_mtime_nsec=0, st_ctime=1556825835 /* 2019-05-02T12:37:15.298850882-0700 */, st_ctime_nsec=298850882}) = 0
+32473 write(1, "Current local time and date: Wed Jun  5 19:15:04 2019\n", 54) = 54
+32473 nanosleep({tv_sec=5, tv_nsec=0}, 0xbffff298) = 0
+32473 time([1559787309 /* 2019-06-05T19:15:09-0700 */]) = 1559787309 (2019-06-05T19:15:09-0700)
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = FutureTimeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 2)

--- a/src/mutator/test_ReverseTime.py
+++ b/src/mutator/test_ReverseTime.py
@@ -1,0 +1,77 @@
+
+''' Tests for the ReverseTimeMutator
+'''
+
+import unittest
+import mock
+from bunch import Bunch
+import tempfile
+from posix_omni_parser import Trace
+
+from ..consts import DEFAULT_CONFIG_PATH
+
+from ReverseTime import ReverseTimeMutator
+
+class TestIdentify(unittest.TestCase):
+  '''Test identify_opportunities
+  '''
+
+  def test_identify_with_no_opportunities(self):
+    '''ReverseTimeMutator should find no opportunities in a trace
+    with no time calls
+    '''
+    trace_data = r'''32473 stat64("/etc/localtime", {st_dev=makedev(8, 1), st_ino=934975, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2845, st_atime=1559715707 /* 2019-06-04T23:21:47.447272045-0700 */, st_atime_nsec=447272045, st_mtime=1555516381 /* 2019-04-17T08:53:01-0700 */, st_mtime_nsec=0, st_ctime=1556825835 /* 2019-05-02T12:37:15.298850882-0700 */, st_ctime_nsec=298850882}) = 0
+32473 write(1, "Current local time and date: Wed Jun  5 19:15:04 2019\n", 54) = 54
+32473 nanosleep({tv_sec=5, tv_nsec=0}, 0xbffff298) = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = ReverseTimeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 0)
+
+
+  def test_identify_with_one_opportunities(self):
+    '''ReverseTimeMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+    trace_data = r'''32473 time([1559787304 /* 2019-06-05T19:15:04-0700 */]) = 1559787304 (2019-06-05T19:15:04-0700)
+32473 stat64("/etc/localtime", {st_dev=makedev(8, 1), st_ino=934975, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2845, st_atime=1559715707 /* 2019-06-04T23:21:47.447272045-0700 */, st_atime_nsec=447272045, st_mtime=1555516381 /* 2019-04-17T08:53:01-0700 */, st_mtime_nsec=0, st_ctime=1556825835 /* 2019-05-02T12:37:15.298850882-0700 */, st_ctime_nsec=298850882}) = 0
+32473 write(1, "Current local time and date: Wed Jun  5 19:15:04 2019\n", 54) = 54
+32473 nanosleep({tv_sec=5, tv_nsec=0}, 0xbffff298) = 0
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = ReverseTimeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 1)
+
+
+  def test_identify_with_many_opportunities(self):
+    '''ReverseTimeMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+
+    trace_data = r'''32473 time([1559787304 /* 2019-06-05T19:15:04-0700 */]) = 1559787304 (2019-06-05T19:15:04-0700)
+32473 stat64("/etc/localtime", {st_dev=makedev(8, 1), st_ino=934975, st_mode=S_IFREG|0644, st_nlink=1, st_uid=0, st_gid=0, st_blksize=4096, st_blocks=8, st_size=2845, st_atime=1559715707 /* 2019-06-04T23:21:47.447272045-0700 */, st_atime_nsec=447272045, st_mtime=1555516381 /* 2019-04-17T08:53:01-0700 */, st_mtime_nsec=0, st_ctime=1556825835 /* 2019-05-02T12:37:15.298850882-0700 */, st_ctime_nsec=298850882}) = 0
+32473 write(1, "Current local time and date: Wed Jun  5 19:15:04 2019\n", 54) = 54
+32473 nanosleep({tv_sec=5, tv_nsec=0}, 0xbffff298) = 0
+32473 time([1559787309 /* 2019-06-05T19:15:09-0700 */]) = 1559787309 (2019-06-05T19:15:09-0700)
+'''
+
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = ReverseTimeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 2)

--- a/src/mutator/test_UnusualFiletype.py
+++ b/src/mutator/test_UnusualFiletype.py
@@ -1,0 +1,92 @@
+
+''' Tests for the UnusualFiletypeMutator
+'''
+
+import unittest
+import mock
+from bunch import Bunch
+import tempfile
+from posix_omni_parser import Trace
+
+from ..consts import DEFAULT_CONFIG_PATH
+
+from UnusualFiletype import UnusualFiletypeMutator
+
+class TestIdentify(unittest.TestCase):
+  '''Test identify_opportunities
+  '''
+
+  def test_identify_with_no_opportunities(self):
+    '''UnusualFiletypeMutator should find no opportunities in a trace
+    with no stat-like calls
+    '''
+    trace_data = '''28725 close(1)                          = 0
+28725 utimensat(AT_FDCWD, ".data.txt.TziqM5", [UTIME_NOW, {1525649303, 124679220}], AT_SYMLINK_NOFOLLOW) = 0
+28725 chmod(".data.txt.TziqM5", 0664)   = 0
+28725 rename(".data.txt.TziqM5", "data.txt") = 0
+28725 _newselect(5, [0], [4], [0], {60, 0}) = 1 (out [4], left {59, 999997})
+28725 write(4, "\4\0\0k\1\0\0\0", 8)    = 8
+28725 _newselect(1, [0], [], [0], {60, 0}) = 1 (in [0], left {59, 999998})
+28725 read(0, "\1\0\0\7\0", 32768)      = 5
+28725 munmap(0xb7b36000, 266240)        = 0
+28725 munmap(0xb7bc8000, 135168)        = 0'''
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = UnusualFiletypeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 0)
+
+
+  def test_identify_with_one_opportunities(self):
+    '''UnusualFiletypeMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+    trace_data = '''28725 close(1)                          = 0
+28725 lstat64(".data.txt.TziqM5", {st_dev=makedev(8, 1), st_ino=50795, st_mode=S_IFREG|0600, st_nlink=1, st_uid=1000, st_gid=1000, st_blksize=4096, st_blocks=8, st_size=13, st_atime=2018/05/06-16:29:03.502410913, st_mtime=2018/05/06-16:29:03.502410913, st_ctime=2018/05/06-16:29:03.502410913}) = 0
+28725 utimensat(AT_FDCWD, ".data.txt.TziqM5", [UTIME_NOW, {1525649303, 124679220}], AT_SYMLINK_NOFOLLOW) = 0
+28725 chmod(".data.txt.TziqM5", 0664)   = 0
+28725 rename(".data.txt.TziqM5", "data.txt") = 0
+28725 _newselect(5, [0], [4], [0], {60, 0}) = 1 (out [4], left {59, 999997})
+28725 write(4, "\4\0\0k\1\0\0\0", 8)    = 8
+28725 _newselect(1, [0], [], [0], {60, 0}) = 1 (in [0], left {59, 999998})
+28725 read(0, "\1\0\0\7\0", 32768)      = 5
+28725 munmap(0xb7b36000, 266240)        = 0
+28725 munmap(0xb7bc8000, 135168)        = 0'''
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = UnusualFiletypeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 1)
+
+
+  def test_identify_with_many_opportunities(self):
+    '''UnusualFiletypeMutator should find one opportunity in a trace with
+    one stat-like call
+    '''
+    trace_data = '''28725 close(1)                          = 0
+28725 lstat64(".data.txt.TziqM5", {st_dev=makedev(8, 1), st_ino=50795, st_mode=S_IFREG|0600, st_nlink=1, st_uid=1000, st_gid=1000, st_blksize=4096, st_blocks=8, st_size=13, st_atime=2018/05/06-16:29:03.502410913, st_mtime=2018/05/06-16:29:03.502410913, st_ctime=2018/05/06-16:29:03.502410913}) = 0
+28725 lstat64(".data.txt.TziqM5", {st_dev=makedev(8, 1), st_ino=50795, st_mode=S_IFREG|0600, st_nlink=1, st_uid=1000, st_gid=1000, st_blksize=4096, st_blocks=8, st_size=13, st_atime=2018/05/06-16:29:03.502410913, st_mtime=2018/05/06-16:29:03.502410913, st_ctime=2018/05/06-16:29:03.502410913}) = 0
+28725 lstat64(".data.txt.TziqM5", {st_dev=makedev(8, 1), st_ino=50795, st_mode=S_IFREG|0600, st_nlink=1, st_uid=1000, st_gid=1000, st_blksize=4096, st_blocks=8, st_size=13, st_atime=2018/05/06-16:29:03.502410913, st_mtime=2018/05/06-16:29:03.502410913, st_ctime=2018/05/06-16:29:03.502410913}) = 0
+28725 utimensat(AT_FDCWD, ".data.txt.TziqM5", [UTIME_NOW, {1525649303, 124679220}], AT_SYMLINK_NOFOLLOW) = 0
+28725 chmod(".data.txt.TziqM5", 0664)   = 0
+28725 rename(".data.txt.TziqM5", "data.txt") = 0
+28725 _newselect(5, [0], [4], [0], {60, 0}) = 1 (out [4], left {59, 999997})
+28725 write(4, "\4\0\0k\1\0\0\0", 8)    = 8
+28725 _newselect(1, [0], [], [0], {60, 0}) = 1 (in [0], left {59, 999998})
+28725 read(0, "\1\0\0\7\0", 32768)      = 5
+28725 munmap(0xb7b36000, 266240)        = 0
+28725 munmap(0xb7bc8000, 135168)        = 0'''
+    trace_file = tempfile.NamedTemporaryFile()
+    trace_file.write(trace_data)
+    trace_file.flush()
+    syscalls = Trace.Trace(trace_file.name, DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle').syscalls
+    trace_file.close()
+    mut = UnusualFiletypeMutator()
+    lines = mut.identify_lines(syscalls)
+    self.assertEqual(len(lines), 3)

--- a/src/rrtest.py
+++ b/src/rrtest.py
@@ -285,7 +285,10 @@ def main():
       #config.set("request_handling_process", "mutator", args.mutator)
       # use the mutator to identify the line we are interested in
       identify_mutator = eval(args.mutator)
-      lines = identify_mutator.identify_lines(test_dir + consts.STRACE_DEFAULT)
+      pickle_file = consts.DEFAULT_CONFIG_PATH + 'syscall_definitions.pickle'
+      syscalls = Trace.Trace(test_dir + consts.STRACE_DEFAULT, pickle_file).syscalls
+      lines = identify_mutator.identify_lines(syscalls)
+
       lines_count = len(lines)
       for j in range(lines_count):
         config.add_section("request_handling_process"+str(j))

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,3 +2,5 @@ smallprog
 callread
 gtodtest
 renametest
+callfsync
+calltime

--- a/test/callfsync.c
+++ b/test/callfsync.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+    printf("Fsync please!\n");
+    fsync(1);
+    return 0;
+}

--- a/test/makefile
+++ b/test/makefile
@@ -1,4 +1,7 @@
-all: callread calltime gtodtest renametest
+all: callfsync callread calltime gtodtest renametest
+
+callfsync: callfsync.c
+	gcc -ggdb -o callfsync callfsync.c
 
 smallprog: smallprog.c
 	gcc -ggdb -o smallprog smallprog.c


### PR DESCRIPTION
This pull request moves mutators from parsing system call traces themselves to receiving system calls from some sort of producer.  The idea is to remove 1) repeated passes through the system call trace when identifying simulation opportunities and 2) avoid situations where the entire system call trace gets read into memory.