### PR TITLE
Fix rrtest to account for lines skipped when moving past syscall_*

### DIFF
--- a/src/rrtest.py
+++ b/src/rrtest.py
@@ -214,9 +214,13 @@ def configure_test(name, mutator, verbosity, trace_line=0, sniplen=5):
       for i in range(len(syscalls)):
         if 'syscall_' in syscalls[i].name:
           break
+
+      off_set = i
       syscalls=syscalls[i:]
 
       lines = identify_mutator.identify_lines(syscalls)
+      for i in range(len(lines)):
+        lines[i] += off_set
 
       lines_count = len(lines)
 


### PR DESCRIPTION
Unusual filetype mutator is still broken